### PR TITLE
Fix: function return type declaration

### DIFF
--- a/frugal-uuid-v1.lisp
+++ b/frugal-uuid-v1.lisp
@@ -57,7 +57,7 @@
                    :clock-seq-low (ldb (byte 8 0) clock-seq)
                    :node (v1-node-id *v1-generator*))))
 
-(declaim (ftype (function () uuid) make-v1))
+(declaim (ftype (function () (values uuid &optional)) make-v1))
 (defun make-v1 ()
   "Generate uuid value (version 1)."
   (unless *v1-generator* (initialize-v1-generator))

--- a/frugal-uuid-v3.lisp
+++ b/frugal-uuid-v3.lisp
@@ -2,14 +2,14 @@
 
 (in-package #:frugal-uuid)
 
-(declaim (ftype (function (t) uuid) make-v3-from-integer))
+(declaim (ftype (function (t) (values uuid &optional)) make-v3-from-integer))
 (defun make-v3-from-integer (i)
   "Set the bits for version 3 and IETF variant, return uuid value."
   (setf (ldb (byte 4 76) i) #x3      ; Set version to 3
         (ldb (byte 2 62) i) #b10)    ; Set variant to IETF
   (from-integer i))
 
-(declaim (ftype (function ((simple-array (unsigned-byte 8))) uuid)
+(declaim (ftype (function ((simple-array (unsigned-byte 8))) (values uuid &optional))
                 make-v3-from-octets))
 (defun make-v3-from-octets (octets)
   "Set the bits for version 3 and IETF variant, return uuid value."

--- a/frugal-uuid-v4.lisp
+++ b/frugal-uuid-v4.lisp
@@ -2,14 +2,14 @@
 
 (in-package #:frugal-uuid)
 
-(declaim (ftype (function (t) uuid) make-v4-from-integer))
+(declaim (ftype (function (t) (values uuid &optional)) make-v4-from-integer))
 (defun make-v4-from-integer (i)
   "Set the bits for version 4 and IETF variant, return uuid value."
   (setf (ldb (byte 4 76) i) #x4      ; Set version to random
         (ldb (byte 2 62) i) #b10)    ; Set variant to IETF
   (from-integer i))
 
-(declaim (ftype (function () uuid) make-v4))
+(declaim (ftype (function () (values uuid &optional)) make-v4))
 (defun make-v4 ()
   "Generate random uuid value (version 4)."
   ;; Generate 128-bit random value

--- a/frugal-uuid-v5.lisp
+++ b/frugal-uuid-v5.lisp
@@ -2,14 +2,14 @@
 
 (in-package #:frugal-uuid)
 
-(declaim (ftype (function (t) uuid) make-v5-from-integer))
+(declaim (ftype (function (t) (values uuid &optional)) make-v5-from-integer))
 (defun make-v5-from-integer (i)
   "Set the bits for version 5 and IETF variant, return uuid value."
   (setf (ldb (byte 4 76) i) #x5      ; Set version to 5
         (ldb (byte 2 62) i) #b10)    ; Set variant to IETF
   (from-integer i))
 
-(declaim (ftype (function ((simple-array (unsigned-byte 8))) uuid)
+(declaim (ftype (function ((simple-array (unsigned-byte 8))) (values uuid &optional))
                 make-v5-from-octets))
 (defun make-v5-from-octets (octets)
   "Set the bits for version 5 and IETF variant, return uuid value."

--- a/frugal-uuid-v7.lisp
+++ b/frugal-uuid-v7.lisp
@@ -73,7 +73,7 @@
                    :clock-seq-low (ldb (byte 8 48) data)
                    :node (ldb (byte 48 0) data))))
 
-(declaim (ftype (function () uuid) make-v7))
+(declaim (ftype (function () (values uuid &optional)) make-v7))
 (defun make-v7 ()
   "Generate uuid value (version 7)."
   (unless *v7-generator* (initialize-v7-generator))

--- a/frugal-uuid.lisp
+++ b/frugal-uuid.lisp
@@ -43,7 +43,7 @@
                  :clock-seq-low (ldb (byte 8 48) i)
                  :node (ldb (byte 48 0) i)))
 
-(declaim (ftype (function (uuid) integer) to-integer))
+(declaim (ftype (function (uuid) (values integer &optional)) to-integer))
 (defun to-integer (uuid)
   "Convert uuid value to integer representation."
   (let ((i 0))
@@ -55,7 +55,7 @@
           (ldb (byte 48 0) i) (node uuid))
     i))
 
-(declaim (ftype (function (string) uuid) from-string))
+(declaim (ftype (function (string) (values uuid &optional)) from-string))
 (defun from-string (s)
   "Parse uuid value from canonical textual representation."
   (unless (eql (length s) 36)
@@ -67,7 +67,7 @@
       :do (error "UUID parse error: expected - at index ~a, found ~a instead." i c))
   (from-integer (parse-integer (remove #\- s) :radix 16)))
 
-(declaim (ftype (function (uuid) string) to-string))
+(declaim (ftype (function (uuid) (values string &optional)) to-string))
 (defun to-string (uuid)
   "Convert uuid value into canonical textual representation."
   (format nil "~(~8,'0x-~4,'0x-~4,'0x-~2,'0x~2,'0x-~12,'0x~)"
@@ -78,7 +78,8 @@
           (clock-seq-low uuid)
           (node uuid)))
 
-(declaim (ftype (function (integer) (simple-array (unsigned-byte 8)))
+(declaim (ftype (function (integer) (values (simple-array (unsigned-byte 8))
+					    &optional))
                 integer-to-octets))
 (defun integer-to-octets (i)
   (loop :with octets := (make-array '(16) :element-type '(unsigned-byte 8))
@@ -88,7 +89,8 @@
                   (ldb (byte 8 bit-index) i))
         :finally (return octets)))
 
-(declaim (ftype (function ((simple-array (unsigned-byte 8))) integer)
+(declaim (ftype (function ((simple-array (unsigned-byte 8)))
+			  (values integer &optional))
                 octets-to-integer))
 (defun octets-to-integer (octets)
   (loop :with i := 0
@@ -98,22 +100,26 @@
                   (aref octets octet-index))
         :finally (return i)))
 
-(declaim (ftype (function (uuid) (simple-array (unsigned-byte 8))) to-octets))
+(declaim (ftype (function (uuid) (values (simple-array (unsigned-byte 8))
+					 &optional))
+		to-octets))
 (defun to-octets (uuid)
   "Create a vector of octets from uuid value."
   (integer-to-octets (to-integer uuid)))
 
-(declaim (ftype (function ((simple-array (unsigned-byte 8))) uuid) from-octets))
+(declaim (ftype (function ((simple-array (unsigned-byte 8)))
+			  (values uuid &optional))
+		from-octets))
 (defun from-octets (octets)
   "Create uuid value from a vector of octets."
   (from-integer (octets-to-integer octets)))
 
-(declaim (ftype (function (uuid) symbol) to-sym))
+(declaim (ftype (function (uuid) (values symbol &optional)) to-sym))
 (defun to-sym (uuid)
   "Create a symbol (uppercase) from uuid value."
   (make-symbol (string-upcase (to-string uuid))))
 
-(declaim (ftype (function (symbol) uuid) from-sym))
+(declaim (ftype (function (symbol) (values uuid &optional)) from-sym))
 (defun from-sym (sym)
   "Create uuid value from a symbol."
   (from-string (format nil "~a" sym)))
@@ -144,7 +150,7 @@
                  :clock-seq-low #xFF
                  :node #xFFFFFFFFFFFF))
 
-(declaim (ftype (function (uuid uuid) boolean) uuid=))
+(declaim (ftype (function (uuid uuid) (values boolean &optional)) uuid=))
 (defun uuid= (x y)
   "Strictly compare uuid inputs for equality.
 

--- a/non-frugal/name-based.lisp
+++ b/non-frugal/name-based.lisp
@@ -2,7 +2,7 @@
 
 (in-package #:frugal-uuid)
 
-(declaim (ftype (function (uuid string) uuid) make-v3))
+(declaim (ftype (function (uuid string) (values uuid &optional)) make-v3))
 (defun make-v3 (namespace name)
   (let ((digest (ironclad:make-digest :md5)))
     (ironclad:update-digest digest (fuuid:to-octets namespace))
@@ -10,7 +10,7 @@
                             (babel:string-to-octets name :encoding :utf-8))
     (fuuid:make-v3-from-octets (ironclad:produce-digest digest))))
 
-(declaim (ftype (function (uuid string) uuid) make-v5))
+(declaim (ftype (function (uuid string) (values uuid &optional)) make-v5))
 (defun make-v5 (namespace name)
     (let ((digest (ironclad:make-digest :sha1)))
       (ironclad:update-digest digest (fuuid:to-octets namespace))


### PR DESCRIPTION
Add `(values ... &optional)` in function return type declarations wherever this was not present yet.